### PR TITLE
KeyCode under firefox Ubuntu

### DIFF
--- a/src/userInput.coffee
+++ b/src/userInput.coffee
@@ -29,6 +29,8 @@ class @UserInput
 
   keyPressed: (event)->
     key = event.keyCode
+    if key == 0
+      key = event.charCode
     if key in [UPPER_LEFT, LOWER_LEFT, UPPER_RIGHT, LOWER_RIGHT]
       @callback key
 


### PR DESCRIPTION
keyCode does not respond on firefox 15 ubuntu. charCode responds (This fix work for me). But it seems that charCode AND keyCode are deprecated... : https://developer.mozilla.org/en-US/docs/DOM/KeyboardEvent

... Context again.
